### PR TITLE
Support context substitution in SimpleLogger

### DIFF
--- a/src/SimpleLogger.php
+++ b/src/SimpleLogger.php
@@ -21,6 +21,16 @@ class SimpleLogger implements LoggerInterface
 
     public function log($level, $message, array $context = array())
     {
+        // The message MAY contain placeholders in the form: {foo} where foo
+        // will be replaced by the context data in key "foo".
+        if (!empty($context)) {
+            $replace = array();
+            foreach ($context as $key => $val) {
+              $replace['{' . $key . '}'] = $val;
+            }
+            $message = strtr($message, $replace);
+        }
+
         if (is_resource($this->writeTo)) {
             fwrite($this->writeTo, "[{$level}] {$message}\n");
         } elseif (is_callable($this->writeTo)) {

--- a/tests/SimpleLoggerTest.php
+++ b/tests/SimpleLoggerTest.php
@@ -12,9 +12,9 @@ class SimpleLoggerTest extends \PHPUnit_Framework_TestCase
     {
         $resource = fopen('php://temp', 'r+');
         $logger = new SimpleLogger($resource);
-        $logger->log('WARN', 'Test');
+        $logger->log('WARN', 'Test {key}', array('key' => 'value'));
         rewind($resource);
-        $this->assertEquals("[WARN] Test\n", stream_get_contents($resource));
+        $this->assertEquals("[WARN] Test value\n", stream_get_contents($resource));
         fclose($resource);
     }
 
@@ -22,11 +22,11 @@ class SimpleLoggerTest extends \PHPUnit_Framework_TestCase
     {
         $called = false;
         $c = function ($message) use (&$called) {
-            $this->assertEquals("[WARN] Test\n", $message);
+            $this->assertEquals("[WARN] Test value\n", $message);
             $called = true;
         };
         $logger = new SimpleLogger($c);
-        $logger->log('WARN', 'Test');
+        $logger->log('WARN', 'Test {key}', array('key' => 'value'));
         $this->assertTrue($called);
     }
 
@@ -34,8 +34,8 @@ class SimpleLoggerTest extends \PHPUnit_Framework_TestCase
     {
         ob_start();
         $logger = new SimpleLogger();
-        $logger->log('WARN', 'Test');
+        $logger->log('WARN', 'Test {key}', array('key' => 'value'));
         $result = ob_get_clean();
-        $this->assertEquals("[WARN] Test\n", $result);
+        $this->assertEquals("[WARN] Test value\n", $result);
     }
 }


### PR DESCRIPTION
See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#3-psrlogloggerinterface:

<blockquote>
The message MAY contain placeholders in the form: {foo} where foo will be replaced by the context data in key "foo".
</blockquote>
